### PR TITLE
fixing general authentication middleware counter

### DIFF
--- a/src/pipeline/authentication/auth.ts
+++ b/src/pipeline/authentication/auth.ts
@@ -125,9 +125,9 @@ export class ApiAuth {
     private sortMiddlewares(middlewares: Array<ApiAuthenticationConfig>, path: string): Array<ApiAuthenticationConfig> {
         const generalMiddlewares = _.filter(middlewares, (value) => {
             if (value.group) {
-                return true;
+                return false;
             }
-            return false;
+            return true;
         });
 
         if (generalMiddlewares.length > 1) {


### PR DESCRIPTION
This bug is causing an error if you trying to use more than 1 group specific authentication methods.
It basically does exactly the opposite what it supposed to do.